### PR TITLE
docs: fix wrong command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This would make a copy of this repository in your account. You will see `<your_u
     - On your local machine, run terminal / cmd and type `git clone <copied_url>`. This creates a new folder named "just-calling-random-api".
     - Go to the folder.
 - Run `npm install` or `yarn` to install all dependencies.
-- Run `npm start` or `yarn install` to start the web app.
+- Run `npm start` or `yarn start` to start the web app.
 
 ## How to contribute?
 


### PR DESCRIPTION
## Description

I'm sorry it should be `yarn start` not `yarn install`